### PR TITLE
feat : plan page -> adding sidemenu(days, friends list)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import Header from './components/Header'; // Header 컴포넌트를 올바르게 import
 import './App.css';
 import Contents from './components/Contents';
+import { Plan } from './pages/Plan';
 
 function App() {
   return (

--- a/src/components/Avartar.tsx
+++ b/src/components/Avartar.tsx
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+
+export const Avartar:React.FC = () => {
+  const [name, setName] = useState('이찬');
+  return(
+    <div className='w-full max-w-24 flex flex-col items-center cursor-pointer'>
+      <div className='size-20 rounded-full bg-slate-200 flex justify-center items-center'>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-10"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+        </svg>
+      </div>
+      <span>{name}</span>
+    </div>
+  );
+
+}

--- a/src/components/Friends.tsx
+++ b/src/components/Friends.tsx
@@ -1,0 +1,17 @@
+import { Avartar } from './Avartar';
+import '../css/common.css';
+
+export const Friends:React.FC = () => {
+  return(
+    <div className='w-full flex flex-col items-center mt-20'>
+      <div className='sign'><span>친구</span></div>
+      <div className='mb-10 cursor-pointer'>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-11">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
+        </svg>
+      </div>
+      <Avartar />
+    </div>
+  );
+
+}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,14 @@
+export const Logo:React.FC = () => {
+  return(
+    <div>
+      {/* 로고 */}
+      <div className="w-20 [font-family:'Pretendard-Medium',Helvetica] font-bold text-transparent text-2xl text-center tracking-[-0.24px] leading-[28.8px]">
+        <span className='text-[#2b79c2] tracking-[-0.06px] leading-[40px]'>
+          Y O G I<br />
+        </span>
+        <span className='text-black tracking-[-0.06px]'>P I N G</span>
+      </div>
+    </div>
+  );
+
+}

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -1,0 +1,14 @@
+import { Logo } from './Logo';
+import { TravelDays } from './TravelDays';
+import { Friends } from './Friends';
+
+export const SideMenu:React.FC = () => {
+  return(
+    <div className = "w-1/6 flex flex-col items-center">
+      <Logo />
+      <TravelDays />
+      <Friends />
+    </div>
+  );
+
+}

--- a/src/components/TravelDays.tsx
+++ b/src/components/TravelDays.tsx
@@ -1,0 +1,11 @@
+import '../css/common.css';
+
+export const TravelDays:React.FC = () => {
+  return(
+    <div className="w-full flex flex-col items-center mt-20">
+      <div className="sign">일정</div>
+      <div className="textbox cursor-pointer">전체 일정</div>
+    </div>
+  );
+
+}

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -1,0 +1,23 @@
+.sign {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #2B75CB;
+  width: 60%;
+  border-radius: 10px;
+  padding: 1rem 1rem;
+  color: #ffff;
+  font-weight: 700;
+  margin-bottom: 4rem;
+}
+
+.textbox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #E6EDF0;
+  width: 60%;
+  border-radius: 10px;
+  padding: 2rem 1rem;
+  font-weight: 600;
+}

--- a/src/pages/Plan.tsx
+++ b/src/pages/Plan.tsx
@@ -1,0 +1,10 @@
+import {SideMenu} from '../components/SideMenu';
+
+export const Plan:React.FC = () => {
+  return(
+    <div className='w-full'>
+      <SideMenu />
+    </div>
+  );
+
+}


### PR DESCRIPTION
# 주요구현내용
로그인시 여행계획 페이지로 넘어가면 나오는 사이드 메뉴(일정리스트, 친구리스트) 틀 작업

# 이슈
라우터 진행하지 않아서 Pages 폴더를 일단 만들어서 Plan에 만들어두었습니다.
컴포넌트들을 묶는게 익숙하지 않아서 일단 해보았는데 수정부분이 말씀해주세요!